### PR TITLE
Added a use for the Exception class

### DIFF
--- a/src/SteamID.php
+++ b/src/SteamID.php
@@ -2,7 +2,9 @@
 
 namespace SteamID;
 
+use Exception;
 use Math_BigInteger;
+
 
 /**
  * Class SteamID


### PR DESCRIPTION
Since the Exception is not included in the namespace, we need to "use" the Exception class. If and when this is merged, could you please do a new release?
